### PR TITLE
fix empty object literal blue click infinite loop

### DIFF
--- a/src/types/parser/randomValue.ts
+++ b/src/types/parser/randomValue.ts
@@ -83,7 +83,7 @@ export function randomTreeOfObjectLiteral(
     const [type_key_tree, type_value_tree] = type_key_value.children
 
     if (type_value_tree.type === TreeNodeType.Invalid) {
-      continue;
+      continue
     }
 
     const { value: key } = type_key_tree
@@ -113,8 +113,8 @@ export function randomTreeOfObjectLiteral(
   }
 
   if (children.length === 0) {
-    let key_tree = getTree("'foo'")
-    let value_tree = getTree("'foo'")
+    const key_tree = getTree("'foo'")
+    const value_tree = getTree("'foo'")
 
     let sample_key_value: TreeNode = {
       value: `${key_tree.value}:${value_tree.value}`,

--- a/src/types/parser/randomValue.ts
+++ b/src/types/parser/randomValue.ts
@@ -79,21 +79,12 @@ export function randomTreeOfObjectLiteral(
 ): TreeNode {
   const children = []
 
-  if (typeTree.children.length === 0) {
-    let key_tree = getTree("'foo'")
-    let value_tree = getTree("'foo'")
-
-    let sample_key_value: TreeNode = {
-      value: `${key_tree.value}:${value_tree.value}`,
-      children: [key_tree, value_tree],
-      type: TreeNodeType.KeyValue,
-    }
-
-    children.push(sample_key_value)
-  }
-
   for (const type_key_value of typeTree.children) {
     const [type_key_tree, type_value_tree] = type_key_value.children
+
+    if (type_value_tree.type === TreeNodeType.Invalid) {
+      continue;
+    }
 
     const { value: key } = type_key_tree
 
@@ -120,6 +111,20 @@ export function randomTreeOfObjectLiteral(
       children.push(key_value_tree)
     }
   }
+
+  if (children.length === 0) {
+    let key_tree = getTree("'foo'")
+    let value_tree = getTree("'foo'")
+
+    let sample_key_value: TreeNode = {
+      value: `${key_tree.value}:${value_tree.value}`,
+      children: [key_tree, value_tree],
+      type: TreeNodeType.KeyValue,
+    }
+
+    children.push(sample_key_value)
+  }
+
   return {
     value: `{${children.map(propValue).join(',')}}`,
     children,

--- a/src/types/parser/randomValue.ts
+++ b/src/types/parser/randomValue.ts
@@ -80,7 +80,7 @@ export function randomTreeOfObjectLiteral(
   const children = []
 
   if (typeTree.children.length === 0) {
-    let key_tree = getTree("'sample_key'")
+    let key_tree = getTree("'foo'")
     let value_tree = getTree("'foo'")
 
     let sample_key_value: TreeNode = {

--- a/src/types/parser/randomValue.ts
+++ b/src/types/parser/randomValue.ts
@@ -79,6 +79,19 @@ export function randomTreeOfObjectLiteral(
 ): TreeNode {
   const children = []
 
+  if (typeTree.children.length === 0) {
+    let key_tree = getTree("'sample_key'")
+    let value_tree = getTree("'foo'")
+
+    let sample_key_value: TreeNode = {
+      value: `${key_tree.value}:${value_tree.value}`,
+      children: [key_tree, value_tree],
+      type: TreeNodeType.KeyValue,
+    }
+
+    children.push(sample_key_value)
+  }
+
   for (const type_key_value of typeTree.children) {
     const [type_key_tree, type_value_tree] = type_key_value.children
 


### PR DESCRIPTION
### Description
Fix - when an empty object literal is blue clicked, then a sample key value pair { 'foo' : VALUE } is added