### PR TITLE
ci: Update `actions/checkout@v2` to `v4`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         node-version: [20.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: npm i
         run: npm i
       - name: npm run setup


### PR DESCRIPTION
GitHub Actions deprecated the version of Node that the v2 and v3 versions of this action use.