### PR TITLE
Improve error handling and cleanup

### DIFF
--- a/src/api/speech/index.ts
+++ b/src/api/speech/index.ts
@@ -108,7 +108,9 @@ export class SpeechRecorder extends EventEmitter_<SpeechRecorderEvents> {
         // throw an exception if it is called twice in a row - swallow it
         try {
           this._recognition.stop()
-        } catch {}
+        } catch {
+          // Expected: stop() throws if called twice per Web Speech API spec
+        }
         // this._recognition.abort()
       }
     }

--- a/src/client/platform/electron/index.ts
+++ b/src/client/platform/electron/index.ts
@@ -20,4 +20,6 @@ app
   .then(() => {
     void createWindow()
   })
-  .catch((err) => {})
+  .catch(() => {
+    process.exit(1)
+  })

--- a/src/system/core/relation/Clamp/f.ts
+++ b/src/system/core/relation/Clamp/f.ts
@@ -1,4 +1,3 @@
-// TODO use `min` and `max`
 export function clamp(a: number, min: number, max: number): number {
   return Math.min(Math.max(a, min), max)
 }

--- a/src/system/platform/component/app/Editor/Component.ts
+++ b/src/system/platform/component/app/Editor/Component.ts
@@ -21975,7 +21975,9 @@ export class Editor_ extends Element<HTMLDivElement, Props_> {
 
     void Promise.all(promises)
       .then(callback)
-      .catch(() => {})
+      .catch(() => {
+        callback()
+      })
   }
 
   private _is_layout_parent_visible = (sub_component_id: string) => {


### PR DESCRIPTION
Small fixes to error handling:

- **Clamp**: Remove stale TODO comment (the params `min` and `max` are already being used)
- **Speech**: Add comment explaining why `stop()` catch is intentionally empty (Web Speech API throws if called twice)
- **Electron**: Exit with code 1 on init failure instead of silently hanging
- **Editor**: Call callback even when animation fails so UI doesn't block